### PR TITLE
SslStream timeout. 

### DIFF
--- a/SyslogNet.Client/Transport/SyslogEncryptedTcpSender.cs
+++ b/SyslogNet.Client/Transport/SyslogEncryptedTcpSender.cs
@@ -19,12 +19,13 @@ namespace SyslogNet.Client.Transport
 			{
 				tcpClient = new TcpClient(hostname, port);
 				tcpClientStream = tcpClient.GetStream();
-				sslStream = new SslStream(tcpClientStream, false, ValidateServerCertificate);
+			    sslStream = new SslStream(tcpClientStream, false, ValidateServerCertificate)
+			    {
+			        ReadTimeout = timeout,
+			        WriteTimeout = timeout
+			    };
 
-			    sslStream.ReadTimeout = timeout;
-			    sslStream.WriteTimeout = timeout;
-
-				sslStream.AuthenticateAsClient(hostname);
+			    sslStream.AuthenticateAsClient(hostname);
 
 				if (!sslStream.IsEncrypted)
 					throw new SecurityException("Could not establish an encrypted connection");

--- a/SyslogNet.Client/Transport/SyslogEncryptedTcpSender.cs
+++ b/SyslogNet.Client/Transport/SyslogEncryptedTcpSender.cs
@@ -1,9 +1,10 @@
+using SyslogNet.Client.Serialization;
 using System;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Security;
 using System.Security.Cryptography.X509Certificates;
-using SyslogNet.Client.Serialization;
+using System.Threading;
 
 namespace SyslogNet.Client.Transport
 {
@@ -12,13 +13,16 @@ namespace SyslogNet.Client.Transport
 		private readonly TcpClient tcpClient;
 		private readonly SslStream sslStream;
 
-		public SyslogEncryptedTcpSender(string hostname, int port)
+        public SyslogEncryptedTcpSender(string hostname, int port, int timeout = Timeout.Infinite)
 		{
 			try
 			{
 				tcpClient = new TcpClient(hostname, port);
 				tcpClientStream = tcpClient.GetStream();
 				sslStream = new SslStream(tcpClientStream, false, ValidateServerCertificate);
+
+			    sslStream.ReadTimeout = timeout;
+			    sslStream.WriteTimeout = timeout;
 
 				sslStream.AuthenticateAsClient(hostname);
 


### PR DESCRIPTION
Adding timeout to sslStream in SyslogEncryptedTcpSender constructor.

Solves issue #2
