### PR TITLE
 SyslogNet.Client: multiple enchancements

### DIFF
--- a/SyslogNet.Client/Serialization/SyslogRfc3164MessageSerializer.cs
+++ b/SyslogNet.Client/Serialization/SyslogRfc3164MessageSerializer.cs
@@ -24,7 +24,6 @@ namespace SyslogNet.Client.Serialization
 			headerBuilder.Append(message.HostName).Append(" ");
 			headerBuilder.Append(message.AppName.IfNotNullOrWhitespace(x => x.EnsureMaxLength(32) + ":"));
 			headerBuilder.Append(message.Message ?? "");
-			headerBuilder.Append("\n");
 
 			byte[] asciiBytes = Encoding.ASCII.GetBytes(headerBuilder.ToString());
 			stream.Write(asciiBytes, 0, asciiBytes.Length);

--- a/SyslogNet.Client/Serialization/SyslogRfc5424MessageSerializer.cs
+++ b/SyslogNet.Client/Serialization/SyslogRfc5424MessageSerializer.cs
@@ -29,7 +29,6 @@ namespace SyslogNet.Client.Serialization
 			messageBuilder.Append(" ").Append(message.AppName.FormatSyslogAsciiField(NilValue, 48, asciiCharsBuffer));
 			messageBuilder.Append(" ").Append(message.ProcId.FormatSyslogAsciiField(NilValue, 128, asciiCharsBuffer));
 			messageBuilder.Append(" ").Append(message.MsgId.FormatSyslogAsciiField(NilValue, 32, asciiCharsBuffer));
-			messageBuilder.Append("\n");
 
 			writeStream(stream, Encoding.ASCII, messageBuilder.ToString());
 

--- a/SyslogNet.Client/Serialization/SyslogRfc5424MessageSerializer.cs
+++ b/SyslogNet.Client/Serialization/SyslogRfc5424MessageSerializer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 
@@ -7,6 +8,8 @@ namespace SyslogNet.Client.Serialization
 	public class SyslogRfc5424MessageSerializer : SyslogMessageSerializerBase, ISyslogMessageSerializer
 	{
 		public const string NilValue = "-";
+		public static readonly HashSet<char> sdNameDisallowedChars = new HashSet<char>() {' ', '=', ']', '"' };
+
 		private readonly char[] asciiCharsBuffer = new char[255];
 
 		public void Serialize(SyslogMessage message, Stream stream)
@@ -18,33 +21,67 @@ namespace SyslogNet.Client.Serialization
 				? message.DateTimeOffset.Value.ToString("yyyy-MM-ddTHH:mm:ss.ffffffK")
 				: null;
 
-			var headerBuilder = new StringBuilder();
-			headerBuilder.Append("<").Append(priorityValue).Append(">");
-			headerBuilder.Append(message.Version);
-			headerBuilder.Append(" ").Append(timestamp.FormatSyslogField(NilValue));
-			headerBuilder.Append(" ").Append(message.HostName.FormatSyslogAsciiField(NilValue, 255, asciiCharsBuffer));
-			headerBuilder.Append(" ").Append(message.AppName.FormatSyslogAsciiField(NilValue, 48, asciiCharsBuffer));
-			headerBuilder.Append(" ").Append(message.ProcId.FormatSyslogAsciiField(NilValue, 128, asciiCharsBuffer));
-			headerBuilder.Append(" ").Append(message.MsgId.FormatSyslogAsciiField(NilValue, 32, asciiCharsBuffer));
-			headerBuilder.Append("\n");
+			var messageBuilder = new StringBuilder();
+			messageBuilder.Append("<").Append(priorityValue).Append(">");
+			messageBuilder.Append(message.Version);
+			messageBuilder.Append(" ").Append(timestamp.FormatSyslogField(NilValue));
+			messageBuilder.Append(" ").Append(message.HostName.FormatSyslogAsciiField(NilValue, 255, asciiCharsBuffer));
+			messageBuilder.Append(" ").Append(message.AppName.FormatSyslogAsciiField(NilValue, 48, asciiCharsBuffer));
+			messageBuilder.Append(" ").Append(message.ProcId.FormatSyslogAsciiField(NilValue, 128, asciiCharsBuffer));
+			messageBuilder.Append(" ").Append(message.MsgId.FormatSyslogAsciiField(NilValue, 32, asciiCharsBuffer));
+			messageBuilder.Append("\n");
 
-			// TODO structured data
+			writeStream(stream, Encoding.ASCII, messageBuilder.ToString());
 
-			bool hasMessage = !String.IsNullOrWhiteSpace(message.Message);
-			if (hasMessage)
-				headerBuilder.Append(" ");
-
-			byte[] asciiBytes = Encoding.ASCII.GetBytes(headerBuilder.ToString());
-			stream.Write(asciiBytes, 0, asciiBytes.Length);
-
-			if (hasMessage)
+			// Structured data
+			foreach(StructuredDataElement sdElement in message.StructuredDataElements)
 			{
-				byte[] utf8Preamble = Encoding.UTF8.GetPreamble();
-				stream.Write(utf8Preamble, 0, utf8Preamble.Length);
+				messageBuilder.Clear()
+					.Append(" ")
+					.Append("[")
+					.Append(sdElement.SdId.FormatSyslogSdnameField(asciiCharsBuffer));
 
-				byte[] messageBytes = Encoding.UTF8.GetBytes(message.Message);
-				stream.Write(messageBytes, 0, messageBytes.Length);
+				writeStream(stream, Encoding.ASCII, messageBuilder.ToString());
+
+				foreach(System.Collections.Generic.KeyValuePair<string, string> sdParam in sdElement.Parameters)
+				{
+					messageBuilder.Clear()
+						.Append(" ")
+						.Append(sdParam.Key.FormatSyslogSdnameField(asciiCharsBuffer))
+						.Append("=")
+						.Append("\"")
+						.Append(
+							sdParam.Value != null ?
+								sdParam.Value
+									.Replace("\\", "\\\\")
+									.Replace("\"", "\\\"")
+									.Replace("]", "\\]")
+								:
+								String.Empty
+						)
+						.Append("\"");
+
+					writeStream(stream, Encoding.UTF8, messageBuilder.ToString());
+				}
+
+				// ]
+				stream.WriteByte(93);
 			}
+
+			if (!String.IsNullOrWhiteSpace(message.Message))
+			{
+				// Space
+				stream.WriteByte(32);
+
+				stream.Write(Encoding.UTF8.GetPreamble(), 0, Encoding.UTF8.GetPreamble().Length);
+				writeStream(stream, Encoding.UTF8, message.Message);
+			}
+		}
+
+		private void writeStream(Stream stream, Encoding encoding, String data)
+		{
+			byte[] streamBytes = encoding.GetBytes(data);
+			stream.Write(streamBytes, 0, streamBytes.Length);
 		}
 	}
 
@@ -69,7 +106,7 @@ namespace SyslogNet.Client.Serialization
 				: s.Length > maxLength ? s.Substring(0, maxLength) : s;
 		}
 
-		public static string FormatSyslogAsciiField(this string s, string replacementValue, int maxLength, char[] charBuffer)
+		public static string FormatSyslogAsciiField(this string s, string replacementValue, int maxLength, char[] charBuffer, Boolean sdName = false)
 		{
 			s = FormatSyslogField(s, replacementValue, maxLength);
 
@@ -78,10 +115,20 @@ namespace SyslogNet.Client.Serialization
 			{
 				char c = s[i];
 				if (c >= 33 && c <= 126)
-					charBuffer[bufferIndex++] = c;
+				{
+					if (!sdName || !SyslogRfc5424MessageSerializer.sdNameDisallowedChars.Contains(c))
+					{
+						charBuffer[bufferIndex++] = c;
+					}
+				}
 			}
 
 			return new string(charBuffer, 0, bufferIndex);
+		}
+
+		public static string FormatSyslogSdnameField(this string s, char[] charBuffer)
+		{
+			return FormatSyslogAsciiField(s, SyslogRfc5424MessageSerializer.NilValue, 32, charBuffer, true);
 		}
 	}
 }

--- a/SyslogNet.Client/SyslogNet.Client.csproj
+++ b/SyslogNet.Client/SyslogNet.Client.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Transport\ISyslogMessageSender.cs" />
     <Compile Include="Transport\SyslogTcpSender.cs" />
     <Compile Include="Transport\SyslogEncryptedTcpSender.cs" />
+    <Compile Include="Transport\SyslogTransportException.cs" />
     <Compile Include="Transport\SyslogUdpSender.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/SyslogNet.Client/Transport/ISyslogMessageSender.cs
+++ b/SyslogNet.Client/Transport/ISyslogMessageSender.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using SyslogNet.Client.Serialization;
 
 namespace SyslogNet.Client.Transport
@@ -6,6 +7,6 @@ namespace SyslogNet.Client.Transport
 	public interface ISyslogMessageSender : IDisposable
 	{
 		void Send(SyslogMessage message, ISyslogMessageSerializer serializer);
-		void Send(SyslogMessage[] messages, ISyslogMessageSerializer serializer);
+		void Send(IEnumerable<SyslogMessage> messages, ISyslogMessageSerializer serializer);
 	}
 }

--- a/SyslogNet.Client/Transport/ISyslogMessageSender.cs
+++ b/SyslogNet.Client/Transport/ISyslogMessageSender.cs
@@ -6,5 +6,6 @@ namespace SyslogNet.Client.Transport
 	public interface ISyslogMessageSender : IDisposable
 	{
 		void Send(SyslogMessage message, ISyslogMessageSerializer serializer);
+		void Send(SyslogMessage[] messages, ISyslogMessageSerializer serializer);
 	}
 }

--- a/SyslogNet.Client/Transport/ISyslogMessageSender.cs
+++ b/SyslogNet.Client/Transport/ISyslogMessageSender.cs
@@ -1,8 +1,9 @@
+using System;
 using SyslogNet.Client.Serialization;
 
 namespace SyslogNet.Client.Transport
 {
-	public interface ISyslogMessageSender
+	public interface ISyslogMessageSender : IDisposable
 	{
 		void Send(SyslogMessage message, ISyslogMessageSerializer serializer);
 	}

--- a/SyslogNet.Client/Transport/SyslogEncryptedTcpSender.cs
+++ b/SyslogNet.Client/Transport/SyslogEncryptedTcpSender.cs
@@ -13,19 +13,19 @@ namespace SyslogNet.Client.Transport
 		private readonly TcpClient tcpClient;
 		private readonly SslStream sslStream;
 
-        public SyslogEncryptedTcpSender(string hostname, int port, int timeout = Timeout.Infinite)
+		public SyslogEncryptedTcpSender(string hostname, int port, int timeout = Timeout.Infinite)
 		{
 			try
 			{
 				tcpClient = new TcpClient(hostname, port);
 				tcpClientStream = tcpClient.GetStream();
-			    sslStream = new SslStream(tcpClientStream, false, ValidateServerCertificate)
-			    {
-			        ReadTimeout = timeout,
-			        WriteTimeout = timeout
-			    };
+				sslStream = new SslStream(tcpClientStream, false, ValidateServerCertificate)
+				{
+					ReadTimeout = timeout,
+					WriteTimeout = timeout
+				};
 
-			    sslStream.AuthenticateAsClient(hostname);
+				sslStream.AuthenticateAsClient(hostname);
 
 				if (!sslStream.IsEncrypted)
 					throw new SecurityException("Could not establish an encrypted connection");

--- a/SyslogNet.Client/Transport/SyslogEncryptedTcpSender.cs
+++ b/SyslogNet.Client/Transport/SyslogEncryptedTcpSender.cs
@@ -8,6 +8,21 @@ namespace SyslogNet.Client.Transport
 {
 	public class SyslogEncryptedTcpSender : SyslogTcpSender
 	{
+		protected MessageTransfer _messageTransfer;
+		public MessageTransfer messageTransfer
+		{
+			get { return _messageTransfer; }
+			set
+			{
+				if (!value.Equals(MessageTransfer.OctetCounting) && transportStream is SslStream)
+				{
+					throw new SyslogTransportException("Non-Transparent-Framing can not be used with TLS transport");
+				}
+
+				_messageTransfer = value;
+			}
+		}
+
 		public SyslogEncryptedTcpSender(string hostname, int port, int timeout = Timeout.Infinite) : base(hostname, port)
 		{
 			startTLS(hostname, timeout);
@@ -25,6 +40,8 @@ namespace SyslogNet.Client.Transport
 
 			if (!((SslStream)transportStream).IsEncrypted)
 				throw new SecurityException("Could not establish an encrypted connection");
+
+			messageTransfer = MessageTransfer.OctetCounting;
 		}
 
 		private static bool ValidateServerCertificate(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)

--- a/SyslogNet.Client/Transport/SyslogTcpSender.cs
+++ b/SyslogNet.Client/Transport/SyslogTcpSender.cs
@@ -7,7 +7,7 @@ namespace SyslogNet.Client.Transport
 	public class SyslogTcpSender : ISyslogMessageSender, IDisposable
 	{
 		private readonly TcpClient tcpClient;
-        private readonly NetworkStream tcpClientStream;
+		private readonly NetworkStream tcpClientStream;
 
 		public SyslogTcpSender(string hostname, int port)
 		{
@@ -26,7 +26,8 @@ namespace SyslogNet.Client.Transport
 		public void Send(SyslogMessage message, ISyslogMessageSerializer serializer)
 		{
 			var datagramBytes = serializer.Serialize(message);
-            tcpClientStream.Write(datagramBytes, 0, datagramBytes.Length);
+
+			tcpClientStream.Write(datagramBytes, 0, datagramBytes.Length);
 			tcpClientStream.Flush();
 
 			// Note: This doesn't work reliably. Can't seem to find a method which does

--- a/SyslogNet.Client/Transport/SyslogTcpSender.cs
+++ b/SyslogNet.Client/Transport/SyslogTcpSender.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Net.Sockets;
 using System.Text;
@@ -63,7 +64,7 @@ namespace SyslogNet.Client.Transport
 				transportStream.Flush();
 		}
 
-		public void Send(SyslogMessage[] messages, ISyslogMessageSerializer serializer)
+		public void Send(IEnumerable<SyslogMessage> messages, ISyslogMessageSerializer serializer)
 		{
 			foreach (SyslogMessage message in messages)
 			{

--- a/SyslogNet.Client/Transport/SyslogTcpSender.cs
+++ b/SyslogNet.Client/Transport/SyslogTcpSender.cs
@@ -63,6 +63,17 @@ namespace SyslogNet.Client.Transport
 				transportStream.Flush();
 		}
 
+		public void Send(SyslogMessage[] messages, ISyslogMessageSerializer serializer)
+		{
+			foreach (SyslogMessage message in messages)
+			{
+				Send(message, serializer, false);
+			}
+
+			if (!(transportStream is NetworkStream))
+				transportStream.Flush();
+		}
+
 		public void Dispose()
 		{
 			if (transportStream != null)

--- a/SyslogNet.Client/Transport/SyslogTcpSender.cs
+++ b/SyslogNet.Client/Transport/SyslogTcpSender.cs
@@ -23,11 +23,11 @@ namespace SyslogNet.Client.Transport
 		{
 			try
 			{
-				messageTransfer = MessageTransfer.OctetCounting;
-				trailer = 10; // LF
-
 				tcpClient = new TcpClient(hostname, port);
 				transportStream = tcpClient.GetStream();
+
+				messageTransfer = MessageTransfer.OctetCounting;
+				trailer = 10; // LF
 			}
 			catch
 			{

--- a/SyslogNet.Client/Transport/SyslogTcpSender.cs
+++ b/SyslogNet.Client/Transport/SyslogTcpSender.cs
@@ -26,13 +26,7 @@ namespace SyslogNet.Client.Transport
 		public void Send(SyslogMessage message, ISyslogMessageSerializer serializer)
 		{
 			var datagramBytes = serializer.Serialize(message);
-
 			tcpClientStream.Write(datagramBytes, 0, datagramBytes.Length);
-			tcpClientStream.Flush();
-
-			// Note: This doesn't work reliably. Can't seem to find a method which does
-			if (!tcpClient.Connected)
-				throw new CommunicationsException("Could not send message because client was disconnected");
 		}
 
 		public void Dispose()

--- a/SyslogNet.Client/Transport/SyslogTcpSender.cs
+++ b/SyslogNet.Client/Transport/SyslogTcpSender.cs
@@ -1,19 +1,31 @@
 using System;
 using System.IO;
 using System.Net.Sockets;
+using System.Text;
 using SyslogNet.Client.Serialization;
 
 namespace SyslogNet.Client.Transport
 {
+	public enum MessageTransfer {
+		OctetCounting		= 0,
+		NonTransparentFraming	= 1
+	}
+
 	public class SyslogTcpSender : ISyslogMessageSender, IDisposable
 	{
 		protected readonly TcpClient tcpClient;
 		protected Stream transportStream;
 
+		public MessageTransfer messageTransfer { get; set; }
+		public byte trailer { get; set; }
+
 		public SyslogTcpSender(string hostname, int port)
 		{
 			try
 			{
+				messageTransfer = MessageTransfer.OctetCounting;
+				trailer = 10; // LF
+
 				tcpClient = new TcpClient(hostname, port);
 				transportStream = tcpClient.GetStream();
 			}
@@ -32,7 +44,20 @@ namespace SyslogNet.Client.Transport
 		protected void Send(SyslogMessage message, ISyslogMessageSerializer serializer, bool flush = true)
 		{
 			var datagramBytes = serializer.Serialize(message);
+
+			if (messageTransfer.Equals(MessageTransfer.OctetCounting))
+			{
+				byte[] messageLength = Encoding.ASCII.GetBytes(datagramBytes.Length.ToString());
+				transportStream.Write(messageLength, 0, messageLength.Length);
+				transportStream.WriteByte(32); // Space
+			}
+
 			transportStream.Write(datagramBytes, 0, datagramBytes.Length);
+
+			if (messageTransfer.Equals(MessageTransfer.NonTransparentFraming))
+			{
+				transportStream.WriteByte(trailer); // LF
+			}
 
 			if (flush && !(transportStream is NetworkStream))
 				transportStream.Flush();

--- a/SyslogNet.Client/Transport/SyslogTransportException.cs
+++ b/SyslogNet.Client/Transport/SyslogTransportException.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace SyslogNet.Client.Transport
+{
+	class SyslogTransportException : Exception
+	{
+		public SyslogTransportException(string message) : base(message)
+		{
+
+		}
+	}
+}

--- a/SyslogNet.Client/Transport/SyslogUdpSender.cs
+++ b/SyslogNet.Client/Transport/SyslogUdpSender.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net.Sockets;
+using System.Text;
 using SyslogNet.Client.Serialization;
 
 namespace SyslogNet.Client.Transport
@@ -17,6 +18,14 @@ namespace SyslogNet.Client.Transport
 		{
 			byte[] datagramBytes = serializer.Serialize(message);
 			udpClient.Send(datagramBytes, datagramBytes.Length);
+		}
+
+		public void Send(SyslogMessage[] messages, ISyslogMessageSerializer serializer)
+		{
+			foreach(SyslogMessage message in messages)
+			{
+				Send(message, serializer);
+			}
 		}
 
 		public void Dispose()

--- a/SyslogNet.Client/Transport/SyslogUdpSender.cs
+++ b/SyslogNet.Client/Transport/SyslogUdpSender.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Net.Sockets;
 using System.Text;
 using SyslogNet.Client.Serialization;
@@ -20,7 +21,7 @@ namespace SyslogNet.Client.Transport
 			udpClient.Send(datagramBytes, datagramBytes.Length);
 		}
 
-		public void Send(SyslogMessage[] messages, ISyslogMessageSerializer serializer)
+		public void Send(IEnumerable<SyslogMessage> messages, ISyslogMessageSerializer serializer)
 		{
 			foreach(SyslogMessage message in messages)
 			{


### PR DESCRIPTION
1. Renamed facilities to better match linux syslog.h
2. Added IDisposable interface to ISyslogMessageSender
3. Fixed minor formatting issues
4. Implemented RFC-5424 structured data
5. Removed useless NetworkStream.Flush()
6. Merged EncryptedTcpSender to TcpSender to remove duplicated code
7. Implemented Octet Counting (RFC 5425/6587) and Non-Transparent-Framing message transfers (RFC 6587) [Without it TCP senders didn't worked at all]
8. Added ISyslogMessageSender::Send() method for sending multiple syslog messages
9. Added option to ignore certificate chain errors for TLS connections

I can split commits to multiple PRs if needed
