### PR TITLE
Implemented ISyslogMessageSender::Reconnect() method.

### DIFF
--- a/SyslogNet.Client/Transport/ISyslogMessageSender.cs
+++ b/SyslogNet.Client/Transport/ISyslogMessageSender.cs
@@ -6,6 +6,7 @@ namespace SyslogNet.Client.Transport
 {
 	public interface ISyslogMessageSender : IDisposable
 	{
+		void Reconnect();
 		void Send(SyslogMessage message, ISyslogMessageSerializer serializer);
 		void Send(IEnumerable<SyslogMessage> messages, ISyslogMessageSerializer serializer);
 	}

--- a/SyslogNet.Client/Transport/SyslogEncryptedTcpSender.cs
+++ b/SyslogNet.Client/Transport/SyslogEncryptedTcpSender.cs
@@ -8,6 +8,7 @@ namespace SyslogNet.Client.Transport
 {
 	public class SyslogEncryptedTcpSender : SyslogTcpSender
 	{
+		protected int IOTimeout;
 		public Boolean IgnoreTLSChainErrors { get; private set; }
 
 		protected MessageTransfer _messageTransfer;
@@ -27,16 +28,23 @@ namespace SyslogNet.Client.Transport
 
 		public SyslogEncryptedTcpSender(string hostname, int port, int timeout = Timeout.Infinite, bool ignoreChainErrors = false) : base(hostname, port)
 		{
+			IOTimeout = timeout;
 			IgnoreTLSChainErrors = ignoreChainErrors;
-			startTLS(hostname, timeout);
+			startTLS();
 		}
 
-		private void startTLS(String hostname, int timeout)
+		public override void Reconnect()
+		{
+			base.Reconnect();
+			startTLS();
+		}
+
+		private void startTLS()
 		{
 			transportStream = new SslStream(tcpClient.GetStream(), false, new RemoteCertificateValidationCallback(ValidateServerCertificate))
 			{
-				ReadTimeout = timeout,
-				WriteTimeout = timeout
+				ReadTimeout = IOTimeout,
+				WriteTimeout = IOTimeout
 			};
 
 			// According to RFC 5425 we MUST support TLS 1.2, but this protocol version only implemented in framework 4.5 and Windows Vista+...

--- a/SyslogNet.Client/Transport/SyslogTcpSender.cs
+++ b/SyslogNet.Client/Transport/SyslogTcpSender.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net.Sockets;
 using System.Text;
+using System.Threading;
 using SyslogNet.Client.Serialization;
 
 namespace SyslogNet.Client.Transport
@@ -14,27 +15,44 @@ namespace SyslogNet.Client.Transport
 
 	public class SyslogTcpSender : ISyslogMessageSender, IDisposable
 	{
-		protected readonly TcpClient tcpClient;
-		protected Stream transportStream;
+		protected String hostname;
+		protected int port;
+
+		protected TcpClient tcpClient = null;
+		protected Stream transportStream = null;
 
 		public MessageTransfer messageTransfer { get; set; }
 		public byte trailer { get; set; }
 
 		public SyslogTcpSender(string hostname, int port)
 		{
+			this.hostname = hostname;
+			this.port = port;
+
+			Connect();
+
+			messageTransfer = MessageTransfer.OctetCounting;
+			trailer = 10; // LF
+		}
+
+		protected void Connect()
+		{
 			try
 			{
 				tcpClient = new TcpClient(hostname, port);
 				transportStream = tcpClient.GetStream();
-
-				messageTransfer = MessageTransfer.OctetCounting;
-				trailer = 10; // LF
 			}
 			catch
 			{
 				Dispose();
 				throw;
 			}
+		}
+
+		public virtual void Reconnect()
+		{
+			Dispose();
+			Connect();
 		}
 
 		public void Send(SyslogMessage message, ISyslogMessageSerializer serializer)
@@ -44,6 +62,11 @@ namespace SyslogNet.Client.Transport
 
 		protected void Send(SyslogMessage message, ISyslogMessageSerializer serializer, bool flush = true)
 		{
+			if(transportStream == null)
+			{
+				throw new IOException("No transport stream exists");
+			}
+
 			var datagramBytes = serializer.Serialize(message);
 
 			if (messageTransfer.Equals(MessageTransfer.OctetCounting))
@@ -78,10 +101,16 @@ namespace SyslogNet.Client.Transport
 		public void Dispose()
 		{
 			if (transportStream != null)
+			{
 				transportStream.Close();
+				transportStream = null;
+			}
 
 			if (tcpClient != null)
+			{
 				tcpClient.Close();
+				tcpClient = null;
+			}
 		}
 	}
 }

--- a/SyslogNet.Client/Transport/SyslogUdpSender.cs
+++ b/SyslogNet.Client/Transport/SyslogUdpSender.cs
@@ -29,6 +29,8 @@ namespace SyslogNet.Client.Transport
 			}
 		}
 
+		public void Reconnect() { /* UDP is connectionless */ }
+
 		public void Dispose()
 		{
 			udpClient.Close();


### PR DESCRIPTION
Right now new instance of ISyslogMessageSender() is needed if Exception is thrown in Send() method.
This change introducing Reconnect() method that can be used to restore connection.
