### PR TITLE
Add "local syslog" feature for Linux, OS X, and other Unix-like systems

### DIFF
--- a/.nuget/NuGet.targets
+++ b/.nuget/NuGet.targets
@@ -41,7 +41,7 @@
     
     <PropertyGroup>
         <!-- NuGet command -->
-        <NuGetExePath Condition=" '$(NuGetExePath)' == '' ">$(NuGetToolsPath)\nuget.exe</NuGetExePath>
+        <NuGetExePath Condition=" '$(NuGetExePath)' == '' ">$(NuGetToolsPath)\NuGet.exe</NuGetExePath>
         <PackageSources Condition=" $(PackageSources) == '' ">@(PackageSource)</PackageSources>
         
         <NuGetCommand Condition=" '$(OS)' == 'Windows_NT'">"$(NuGetExePath)"</NuGetCommand>

--- a/SyslogNet.Client.Tests/Serialization/SyslogLocalMessageSerializerTests.cs
+++ b/SyslogNet.Client.Tests/Serialization/SyslogLocalMessageSerializerTests.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using SyslogNet.Client.Serialization;
+using Xunit;
+using Xunit.Extensions;
+
+namespace SyslogNet.Client.Tests.Serialization
+{
+	public  class SyslogLocalMessageSerializerTests
+	{
+		private readonly SyslogLocalMessageSerializer sut;
+
+		public SyslogLocalMessageSerializerTests()
+		{
+			sut = new SyslogLocalMessageSerializer();
+		}
+
+		[Fact]
+		public void SerializesMessageCorrectly()
+		{
+			const string message = "Foo and bar";
+
+			var msg = CreateMinimalSyslogMessage(Facility.UserLevelMessages, Severity.Error, "MyApp", message);
+
+			string serializedMsg = sut.Serialize(msg);
+			Assert.Equal(serializedMsg, message);
+		}
+
+		private static SyslogMessage CreateMinimalSyslogMessage(
+			Facility facility,
+			Severity severity,
+			string appName = null,
+			string message = null)
+		{
+			return new SyslogMessage(facility, severity, appName, message);
+		}
+	}
+}

--- a/SyslogNet.Client.Tests/Serialization/SyslogSerializerExtensionsForTests.cs
+++ b/SyslogNet.Client.Tests/Serialization/SyslogSerializerExtensionsForTests.cs
@@ -31,5 +31,18 @@ namespace SyslogNet.Client.Tests.Serialization
 					return reader.ReadLine();
 			}
 		}
+
+		public static string Serialize(this SyslogLocalMessageSerializer serializer, SyslogMessage message)
+		{
+			using (var stream = new MemoryStream())
+			{
+				serializer.Serialize(message, stream);
+				stream.Flush();
+				stream.Position = 0;
+
+				using (var reader = new StreamReader(stream, Encoding.UTF8))
+					return reader.ReadLine();
+			}
+		}
 	}
 }

--- a/SyslogNet.Client.Tests/SyslogNet.Client.Tests.csproj
+++ b/SyslogNet.Client.Tests/SyslogNet.Client.Tests.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{2D6094E8-8483-4B91-9D5E-BF98B070763F}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -64,7 +62,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/SyslogNet.Client.Tests/SyslogNet.Client.Tests.csproj
+++ b/SyslogNet.Client.Tests/SyslogNet.Client.Tests.csproj
@@ -50,6 +50,7 @@
     <Compile Include="Serialization\SyslogRfc3164MessageSerializerTests.cs" />
     <Compile Include="Serialization\SyslogSerializerExtensionsForTests.cs" />
     <Compile Include="Serialization\SyslogRfc5424MessageSerializerTests.cs" />
+    <Compile Include="Serialization\SyslogLocalMessageSerializerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/SyslogNet.Client/Serialization/SyslogLocalMessageSerializer.cs
+++ b/SyslogNet.Client/Serialization/SyslogLocalMessageSerializer.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Text;
+using System.IO;
+
+namespace SyslogNet.Client.Serialization
+{
+	public class SyslogLocalMessageSerializer : SyslogMessageSerializerBase, ISyslogMessageSerializer
+	{
+		public Encoding Encoding { get; set; }
+
+		// Default constructor: produce no BOM in local syslog messages
+		public SyslogLocalMessageSerializer() : this(false) { ; }
+
+		// Optionally produce a BOM in local syslog messages by passing true here
+		// (This can produce problems with some older syslog programs, so default is false)
+		public SyslogLocalMessageSerializer(bool useBOM) {
+			Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: useBOM);
+		}
+
+		public void Serialize(SyslogMessage message, Stream stream)
+		{
+			// Local syslog serialization only cares about the Message string
+			if (!String.IsNullOrWhiteSpace(message.Message))
+			{
+				byte[] streamBytes = Encoding.GetBytes(message.Message);
+				stream.Write(streamBytes, 0, streamBytes.Length);
+			}
+		}
+	}
+}

--- a/SyslogNet.Client/SyslogMessage.cs
+++ b/SyslogNet.Client/SyslogMessage.cs
@@ -15,6 +15,35 @@ namespace SyslogNet.Client
 		private readonly IEnumerable<StructuredDataElement> structuredDataElements;
 		private readonly DateTimeOffset? dateTimeOffset;
 		
+		public static Facility DefaultFacility = Facility.UserLevelMessages;
+		public static Severity DefaultSeverity = Severity.Informational;
+
+		/// <summary>
+		/// Convenience overload for sending local syslog messages with default facility (UserLevelMessages)
+		/// </summary>
+		public SyslogMessage(
+			Severity severity,
+			string appName,
+			string message)
+		: this(DefaultFacility, severity, appName, message)
+		{
+		}
+
+		/// <summary>
+		/// Constructor for use when sending local syslog messages
+		/// </summary>
+		public SyslogMessage(
+			Facility facility,
+			Severity severity,
+			string appName,
+			string message)
+		{
+			this.facility = facility;
+			this.severity = severity;
+			this.appName = appName;
+			this.message = message;
+		}
+
 		/// <summary>
 		/// Constructor for use when sending RFC 3164 messages
 		/// </summary>

--- a/SyslogNet.Client/SyslogNet.Client.csproj
+++ b/SyslogNet.Client/SyslogNet.Client.csproj
@@ -55,11 +55,15 @@
     <Compile Include="Serialization\SyslogRfc5424MessageSerializer.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Serialization\SyslogLocalMessageSerializer.cs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="Transport\ISyslogMessageSender.cs" />
     <Compile Include="Transport\SyslogTcpSender.cs" />
     <Compile Include="Transport\SyslogEncryptedTcpSender.cs" />
     <Compile Include="Transport\SyslogTransportException.cs" />
     <Compile Include="Transport\SyslogUdpSender.cs" />
+    <Compile Include="Transport\SyslogLocalSender.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/SyslogNet.Client/Transport/SyslogLocalSender.cs
+++ b/SyslogNet.Client/Transport/SyslogLocalSender.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using SyslogNet.Client.Serialization;
+
+namespace SyslogNet.Client.Transport
+{
+	public class SyslogLocalSender : ISyslogMessageSender, IDisposable
+	{
+		// Will not work on Windows, as this relies on Unix system calls
+		public SyslogLocalSender()
+		{
+			PlatformID platform = Environment.OSVersion.Platform;
+			if (!(platform == PlatformID.MacOSX || platform == PlatformID.Unix)) {
+				throw new CommunicationsException("SyslogLocalSender is only available on Unix-like systems (e.g., Linux, BSD, OS X)");
+			}
+		}
+
+		[DllImport("libc", ExactSpelling=true)]
+		// Because openlog() makes a copy of the char *ident that it gets passed, we have to
+		// make sure it gets marshalled into unmanaged memory. Hence the IntPtr ident parameter.
+		protected static extern void openlog(IntPtr ident, int option, int facility);
+
+		[DllImport("libc", CharSet=CharSet.Ansi, ExactSpelling=true, CallingConvention=CallingConvention.Cdecl)]
+		protected static extern void syslog(int priority, string fmt, byte[] msg);
+
+		[DllImport("libc", ExactSpelling=true)]
+		protected static extern void closelog();
+
+		public static ISyslogMessageSerializer defaultSerializer = new SyslogLocalMessageSerializer();
+
+		public static int CalculatePriorityValue(Facility? facility, Severity? severity)
+		{
+			return ((int)facility << 3) | (int)severity;
+		}
+
+		public void Reconnect()
+		{
+			// Not needed; glibc syslog() is effectively "connectionless"
+		}
+
+		protected IntPtr MarshalIdent(string ident)
+		{
+			return (ident == null) ? IntPtr.Zero : Marshal.StringToHGlobalAnsi(ident);
+		}
+
+		protected void DisposeOfIdent(IntPtr identPtr)
+		{
+			if (identPtr != IntPtr.Zero)
+				Marshal.FreeHGlobal(identPtr);
+		}
+
+		protected ISyslogMessageSerializer EnsureValidSerializer(ISyslogMessageSerializer serializer) {
+			return serializer ?? defaultSerializer;
+		}
+
+		protected void SendToSyslog(SyslogMessage message, ISyslogMessageSerializer serializer)
+		{
+			int priority = CalculatePriorityValue(message.Facility, message.Severity);
+			serializer = EnsureValidSerializer(serializer);
+			byte[] data = serializer.Serialize(message);
+			syslog(priority, "%s", data);
+		}
+
+		public void Send(SyslogMessage message, ISyslogMessageSerializer serializer)
+		{
+			IntPtr ident = IntPtr.Zero;
+			try
+			{
+				ident = MarshalIdent(message.AppName);
+				openlog(ident, (int)SyslogOptions.LogPid, CalculatePriorityValue(message.Facility, 0));
+				SendToSyslog(message, serializer);
+			}
+			finally
+			{
+				closelog();
+				DisposeOfIdent(ident);
+			}
+		}
+
+		public void Send(IEnumerable<SyslogMessage> messages, ISyslogMessageSerializer serializer)
+		{
+			// Slightly tricky, since we need to get the appName out of the first message before
+			// looping, so we can't just use foreach(). Using an explicit iterator works, though.
+			IntPtr ident = IntPtr.Zero;
+			using (IEnumerator<SyslogMessage> iterator = messages.GetEnumerator())
+			{
+				try
+				{
+					if (iterator.MoveNext())
+					{
+						SyslogMessage message = iterator.Current;
+						ident = MarshalIdent(message.AppName);
+						openlog(ident, (int)SyslogOptions.LogPid, CalculatePriorityValue(message.Facility, 0));
+						SendToSyslog(message, serializer);
+					}
+					while (iterator.MoveNext())
+					{
+						SendToSyslog(iterator.Current, serializer);
+					}
+				}
+				finally
+				{
+					closelog();
+					DisposeOfIdent(ident);
+				}
+			}
+		}
+
+		// Convenience overloads since there's only one possible serializer for local syslog messages
+		public void Send(SyslogMessage message)
+		{
+			Send(message, defaultSerializer);
+		}
+		public void Send(IEnumerable<SyslogMessage> messages)
+		{
+			Send(messages, defaultSerializer);
+		}
+
+		public void Dispose()
+		{
+			// No action needed as we don't keep any state
+		}
+
+		[Flags]
+		protected enum SyslogOptions : int {
+			LogPid = 1,
+			LogToConsoleIfErrorSendingToSyslog = 2,
+			DelayOpenUntilFirstSyslogCall = 4,
+			DontDelayOpen = 8,
+			DEPRECATED_DontWaitForConsoleForks = 16,
+			AlsoLogToStderr = 32
+		}
+	}
+}

--- a/TesterApp/TesterApp.csproj
+++ b/TesterApp/TesterApp.csproj
@@ -61,7 +61,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
Many Linux distributions come with the default syslog set to accept local messages only (e.g., messages coming in via the `/dev/log` Unix socket), and do not (by default) listen on TCP or UDP. So for any C# projects running on Linux that want to log messages to syslog, it would be helpful to have a SyslogLocalSender class to send messages to the local syslog over Unix sockets.

I've implemented a SyslogLocalSender that uses the Unix system calls `openlog()`, `syslog()`, and `closelog()` from the standard C library. This will, naturally, only work on Linux systems, so I've added a test in SyslogLocalSender to throw an exception if it is run from a Windows system. (It will currently be quite happy to run on an OS X system, but I don't have an OS X system available to me to test this, so if it actually fails on OS X, the `Environment.OSVersion.Platform` check in SyslogLocalSender will need to be tweaked to forbid OS X as well.)

I've tested this on Linux Mint 17.2 (based on Ubuntu Trusty), Debian Jessie, and Debian Wheezy, and it worked just fine on all three systems. I've also included unit tests for the SyslogLocalMessageSerializer, insofar as such a simple class _can_ be unit tested.

One interesting thing to note is that the `rsyslog` version found in Linux Mint 17.2 suppresses consecutive duplicate syslog messages. So on Mint, running `mono TesterApp.exe -m "Hello world"` only produces a single log message, but running `TesterApp.exe` without specifying a `-m` option will produce two different log messages. (Because when no `-m` option is given, TesterApp creates two messages with different content -- they contain timestamps 5 seconds apart, so their message content is not identical, and thus `rsyslog` puts both of them into `/var/log/syslog`.)

Many fields in the SyslogMessage class are meaningless in a local syslog message, including timestamp and hostname, so I've also created a new SyslogMessage constructor for local messages, with which the user can specify the bare minimum necessary to get the job done.

I'd be happy to tweak to this pull request as needed, if any further tweaks prove necessary.
