### PR TITLE
StructuredData was missing NILVALUE on RFC 5424 serializer

### DIFF
--- a/SyslogNet.Client.Tests/Serialization/SyslogRfc5424MessageSerializerTests.cs
+++ b/SyslogNet.Client.Tests/Serialization/SyslogRfc5424MessageSerializerTests.cs
@@ -23,7 +23,7 @@ namespace SyslogNet.Client.Tests.Serialization
 			var msg = CreateMinimalSyslogMessage(facility, severity);
 
 			string serializedMsg = sut.Serialize(msg);
-			Assert.Equal(String.Format("<{0}>1 - - - - -", expectedPriorityValue), serializedMsg);
+			Assert.Equal(String.Format("<{0}>1 - - - - - -", expectedPriorityValue), serializedMsg);
 		}
 
 		[Fact]
@@ -35,7 +35,7 @@ namespace SyslogNet.Client.Tests.Serialization
 			var msg = CreateMinimalSyslogMessage(Facility.UserLevelMessages, Severity.Error, utcDateTime);
 
 			string serializedMsg = sut.Serialize(msg);
-			Assert.Equal(String.Format("<11>1 {0} - - - -", expectedTimestamp), serializedMsg);
+			Assert.Equal(String.Format("<11>1 {0} - - - - -", expectedTimestamp), serializedMsg);
 		}
 
 		[Fact]
@@ -48,7 +48,7 @@ namespace SyslogNet.Client.Tests.Serialization
 			var msg = CreateMinimalSyslogMessage(Facility.UserLevelMessages, Severity.Error, knownDateTimeOffset);
 
 			string serializedMsg = sut.Serialize(msg);
-			Assert.Equal(String.Format("<11>1 {0} - - - -", expectedTimestamp), serializedMsg);
+			Assert.Equal(String.Format("<11>1 {0} - - - - -", expectedTimestamp), serializedMsg);
 		}
 
 		[Theory]
@@ -59,7 +59,7 @@ namespace SyslogNet.Client.Tests.Serialization
 			var msg = CreateMinimalSyslogMessage(Facility.UserLevelMessages, Severity.Error, hostName: hostName);
 
 			string serializedMsg = sut.Serialize(msg);
-			Assert.Equal(String.Format("<11>1 - {0} - - -", expectedHostName), serializedMsg);
+			Assert.Equal(String.Format("<11>1 - {0} - - - -", expectedHostName), serializedMsg);
 		}
 
 		[Theory]
@@ -70,7 +70,7 @@ namespace SyslogNet.Client.Tests.Serialization
 			var msg = CreateMinimalSyslogMessage(Facility.UserLevelMessages, Severity.Error, appName: appName);
 
 			string serializedMsg = sut.Serialize(msg);
-			Assert.Equal(String.Format("<11>1 - - {0} - -", expectedAppName), serializedMsg);
+			Assert.Equal(String.Format("<11>1 - - {0} - - -", expectedAppName), serializedMsg);
 		}
 
 		[Theory]
@@ -81,7 +81,7 @@ namespace SyslogNet.Client.Tests.Serialization
 			var msg = CreateMinimalSyslogMessage(Facility.UserLevelMessages, Severity.Error, procId: procId);
 
 			string serializedMsg = sut.Serialize(msg);
-			Assert.Equal(String.Format("<11>1 - - - {0} -", expectedProcId), serializedMsg);
+			Assert.Equal(String.Format("<11>1 - - - {0} - -", expectedProcId), serializedMsg);
 		}
 
 		[Theory]
@@ -92,7 +92,7 @@ namespace SyslogNet.Client.Tests.Serialization
 			var msg = CreateMinimalSyslogMessage(Facility.UserLevelMessages, Severity.Error, msgId: msgId);
 
 			string serializedMsg = sut.Serialize(msg);
-			Assert.Equal(String.Format("<11>1 - - - - {0}", expectedMsgId), serializedMsg);
+			Assert.Equal(String.Format("<11>1 - - - - {0} -", expectedMsgId), serializedMsg);
 		}
 
 		[Theory]
@@ -104,7 +104,7 @@ namespace SyslogNet.Client.Tests.Serialization
 
 			string serializedMsg = sut.Serialize(msg);
 
-			string messagePrefix = "<11>1 - - - - - ";
+			string messagePrefix = "<11>1 - - - - - - ";
 			Assert.True(serializedMsg.StartsWith(messagePrefix));
 
 			int messageIndex = 0;

--- a/SyslogNet.Client/Serialization/SyslogRfc5424MessageSerializer.cs
+++ b/SyslogNet.Client/Serialization/SyslogRfc5424MessageSerializer.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
+using System.Linq;
 
 namespace SyslogNet.Client.Serialization
 {
@@ -33,25 +33,11 @@ namespace SyslogNet.Client.Serialization
 
 			writeStream(stream, Encoding.ASCII, messageBuilder.ToString());
 
-			AddStructuredData(message, stream, messageBuilder);
-
-			if (!String.IsNullOrWhiteSpace(message.Message))
-			{
-				// Space
-				stream.WriteByte(32);
-
-				stream.Write(Encoding.UTF8.GetPreamble(), 0, Encoding.UTF8.GetPreamble().Length);
-				writeStream(stream, Encoding.UTF8, message.Message);
-			}
-		}
-
-		private void AddStructuredData(SyslogMessage message, Stream stream, StringBuilder messageBuilder)
-		{
-			// Structured data
 			var structuredData = message.StructuredDataElements.ToList();
 			if (structuredData.Any())
 			{
-				foreach (StructuredDataElement sdElement in structuredData)
+				// Structured data
+				foreach(StructuredDataElement sdElement in structuredData)
 				{
 					messageBuilder.Clear()
 						.Append(" ")
@@ -69,7 +55,7 @@ namespace SyslogNet.Client.Serialization
 							.Append("\"")
 							.Append(
 								sdParam.Value != null ?
-								sdParam.Value
+									sdParam.Value
 										.Replace("\\", "\\\\")
 										.Replace("\"", "\\\"")
 										.Replace("]", "\\]")
@@ -87,9 +73,17 @@ namespace SyslogNet.Client.Serialization
 			}
 			else
 			{
-				// " -"
 				writeStream(stream, Encoding.ASCII, " ");
 				writeStream(stream, Encoding.ASCII, NilValue);
+			}
+
+			if (!String.IsNullOrWhiteSpace(message.Message))
+			{
+				// Space
+				stream.WriteByte(32);
+
+				stream.Write(Encoding.UTF8.GetPreamble(), 0, Encoding.UTF8.GetPreamble().Length);
+				writeStream(stream, Encoding.UTF8, message.Message);
 			}
 		}
 


### PR DESCRIPTION
When StructuredData is missing, as per RFC, a NILVALUE should be included.
RFC 5424 Section 6: https://tools.ietf.org/html/rfc5424#section-6

STRUCTURED-DATA = NILVALUE / 1*SD-ELEMENT
Also found here on brocade.com:

```
* STRUCTURED-DATA — This provides a mechanism to express information in a well-defined and interpretable data format as per RFC 5424. STRUCTURED-DATA can contain zero, one, or multiple SD elements. In case of zero structured data elements, the STRUCTURED-DATA field uses NILVALUE.
```

http://www.brocade.com/content/html/en/configuration-guide/fastiron-08040-monitoringguide/GUID-88F338BA-B7BF-485C-B1DE-7418710452A6.html

For that reason, it is to my understanding that a completely 'empty' but valid message would look like:

`<0>1 - - - - - -`

This PR closes issue: bruno-garcia/SharpSyslogServer#6
