### PR TITLE
Chinese Issue and adding optional MessageTransfer parameter in SyslogTcpSender constructor 

### DIFF
--- a/SyslogNet.Client/Serialization/SyslogRfc3164MessageSerializer.cs
+++ b/SyslogNet.Client/Serialization/SyslogRfc3164MessageSerializer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.IO;
 using System.Text;
 
@@ -15,7 +16,7 @@ namespace SyslogNet.Client.Serialization
 			{
 				var dt = message.DateTimeOffset.Value;
 				var day = dt.Day < 10 ? " " + dt.Day : dt.Day.ToString(); // Yes, this is stupid but it's in the spec
-				timestamp = String.Concat(dt.ToString("MMM "), day, dt.ToString(" HH:mm:ss"));
+                timestamp = String.Concat(dt.ToString("MMM ", CultureInfo.CreateSpecificCulture("en-US")), day, dt.ToString(" HH:mm:ss"));
 			}
 
 			var headerBuilder = new StringBuilder();
@@ -25,7 +26,7 @@ namespace SyslogNet.Client.Serialization
 			headerBuilder.Append(message.AppName.IfNotNullOrWhitespace(x => x.EnsureMaxLength(32) + ":"));
 			headerBuilder.Append(message.Message ?? "");
 
-			byte[] asciiBytes = Encoding.ASCII.GetBytes(headerBuilder.ToString());
+			byte[] asciiBytes = Encoding.UTF8.GetBytes(headerBuilder.ToString());
 			stream.Write(asciiBytes, 0, asciiBytes.Length);
 		}
 	}

--- a/SyslogNet.Client/Transport/SyslogTcpSender.cs
+++ b/SyslogNet.Client/Transport/SyslogTcpSender.cs
@@ -24,14 +24,14 @@ namespace SyslogNet.Client.Transport
 		public virtual MessageTransfer messageTransfer { get; set; }
 		public byte trailer { get; set; }
 
-		public SyslogTcpSender(string hostname, int port)
+        public SyslogTcpSender(string hostname, int port, MessageTransfer messageTransferMethod = MessageTransfer.OctetCounting)
 		{
 			this.hostname = hostname;
 			this.port = port;
 
 			Connect();
 
-			messageTransfer = MessageTransfer.OctetCounting;
+            messageTransfer = messageTransferMethod;
 			trailer = 10; // LF
 		}
 

--- a/SyslogNet.sln
+++ b/SyslogNet.sln
@@ -1,8 +1,6 @@
-﻿
-Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.40629.0
-MinimumVisualStudioVersion = 10.0.40219.1
+
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TesterApp", "TesterApp\TesterApp.csproj", "{9D7482EB-EA3F-4047-9E79-C80EC8E18FED}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{889FB071-3ADE-4C7F-9079-E4E016FE8B90}"

--- a/SyslogNet.sln
+++ b/SyslogNet.sln
@@ -1,6 +1,8 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.40629.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TesterApp", "TesterApp\TesterApp.csproj", "{9D7482EB-EA3F-4047-9E79-C80EC8E18FED}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{889FB071-3ADE-4C7F-9079-E4E016FE8B90}"
@@ -16,6 +18,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SyslogNet.Client.Tests", "SyslogNet.Client.Tests\SyslogNet.Client.Tests.csproj", "{2D6094E8-8483-4B91-9D5E-BF98B070763F}"
 EndProject
 Global
+	GlobalSection(SubversionScc) = preSolution
+		Svn-Managed = True
+		Manager = AnkhSVN - Subversion Support for Visual Studio
+	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug|Mixed Platforms = Debug|Mixed Platforms

--- a/SyslogNet.sln
+++ b/SyslogNet.sln
@@ -1,4 +1,4 @@
-
+ 
 Microsoft Visual Studio Solution File, Format Version 11.00
 # Visual Studio 2010
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TesterApp", "TesterApp\TesterApp.csproj", "{9D7482EB-EA3F-4047-9E79-C80EC8E18FED}"

--- a/SyslogNet.sln
+++ b/SyslogNet.sln
@@ -18,10 +18,6 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SyslogNet.Client.Tests", "SyslogNet.Client.Tests\SyslogNet.Client.Tests.csproj", "{2D6094E8-8483-4B91-9D5E-BF98B070763F}"
 EndProject
 Global
-	GlobalSection(SubversionScc) = preSolution
-		Svn-Managed = True
-		Manager = AnkhSVN - Subversion Support for Visual Studio
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug|Mixed Platforms = Debug|Mixed Platforms

--- a/SyslogNet.sln
+++ b/SyslogNet.sln
@@ -1,4 +1,4 @@
- 
+
 Microsoft Visual Studio Solution File, Format Version 11.00
 # Visual Studio 2010
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TesterApp", "TesterApp\TesterApp.csproj", "{9D7482EB-EA3F-4047-9E79-C80EC8E18FED}"


### PR DESCRIPTION
There are two issue found when use SyslogNet in Chinese Windows operating system.

message.DateTimeOffset.Value.Tostring("MMM ") get the Chinese month string in SyslogRfc3164MessageSerializer.cs
Chinese month string will show in the message header, that cause syslog server consider the syslog header as message text.
e.g. 
八月 27 22:45:23 HOSTNAME ........(Wrong)
Aug 27 22:45:23 HOSTNAME ......(Correct)

Not support Chinese character in message.

Here is the fix in SyslogRfc3164MessageSerializer.cs
1. Add en-US CultureInfo when get the month string.
2. Change the encoding from ASCII to UTF8.

The SyslogTcpSender constructor use OctetCounting as default Transfer method.  We application ISyslogMessageSender to create a SyslogTcpSender , it can't not change the MessageTransfer. However , some syslog server (e.q. Syslog-ng) use NonTransparentFraming transfer method. So, add a optional transfer method could solve this issue.

public SyslogTcpSender(string hostname, int port, MessageTransfer messageTransferMethod = MessageTransfer.OctetCounting)
