### PR TITLE
Not having structured data elements caused a NullReferenceException

### DIFF
--- a/SyslogNet.Client/Serialization/SyslogRfc5424MessageSerializer.cs
+++ b/SyslogNet.Client/Serialization/SyslogRfc5424MessageSerializer.cs
@@ -33,8 +33,8 @@ namespace SyslogNet.Client.Serialization
 
 			writeStream(stream, Encoding.ASCII, messageBuilder.ToString());
 
-			var structuredData = message.StructuredDataElements.ToList();
-			if (structuredData.Any())
+			var structuredData = message.StructuredDataElements?.ToList();
+			if (structuredData != null && structuredData.Any())
 			{
 				// Structured data
 				foreach(StructuredDataElement sdElement in structuredData)


### PR DESCRIPTION
This code was generating a `NullReferenceException` because the message doesn't have structured data elements:

```
using System;
using SyslogNet.Client;
using SyslogNet.Client.Serialization;
using SyslogNet.Client.Transport;

namespace ConsoleApplication
{
    internal class Program
    {
        public static void Main(string[] args)
        {
            var tcpSender = new SyslogTcpSender("192.168.12.23", 1000);

            var msg = new SyslogMessage(Severity.Error, "MyApp", "My message");
            var serializer = new SyslogRfc5424MessageSerializer();
            tcpSender.Send(msg, serializer);
        }
    }
}
```