### PR TITLE
Removing unnecessary copy on serialization

### DIFF
--- a/SyslogNet.Client/Serialization/SyslogRfc5424MessageSerializer.cs
+++ b/SyslogNet.Client/Serialization/SyslogRfc5424MessageSerializer.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
-using System.Linq;
 
 namespace SyslogNet.Client.Serialization
 {
@@ -33,8 +32,8 @@ namespace SyslogNet.Client.Serialization
 
 			writeStream(stream, Encoding.ASCII, messageBuilder.ToString());
 
-			var structuredData = message.StructuredDataElements?.ToList();
-			if (structuredData != null && structuredData.Any())
+			var structuredData = message.StructuredDataElements;
+			if (structuredData != null && structuredData.Length != 0)
 			{
 			    // Space
 			    stream.WriteByte(32);

--- a/SyslogNet.Client/SyslogMessage.cs
+++ b/SyslogNet.Client/SyslogMessage.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 namespace SyslogNet.Client
 {
@@ -12,7 +11,7 @@ namespace SyslogNet.Client
 		private readonly string procId;
 		private readonly string msgId;
 		private readonly string message;
-		private readonly IEnumerable<StructuredDataElement> structuredDataElements;
+		private readonly StructuredDataElement[] structuredDataElements;
 		private readonly DateTimeOffset? dateTimeOffset;
 		
 		public static Facility DefaultFacility = Facility.UserLevelMessages;
@@ -128,7 +127,7 @@ namespace SyslogNet.Client
 			get { return message; }
 		}
 
-		public IEnumerable<StructuredDataElement> StructuredDataElements
+		public StructuredDataElement[] StructuredDataElements
 		{
 			get { return structuredDataElements; }
 		}


### PR DESCRIPTION
SyslogMessage.StructuredDataElement is accepted as an array but was being stored and surfaced through the get property as an IEnumerable<>. This required a .ToList() on every serialization request as well as a .Any().

Changing the backing field and get property to an array removes the copy from the .ToList() and allows a .Length != 0 instead of the Linq .Any().

It is mostly a non-breaking change as any usage of the SyslogMessage.StructuredDataElement assuming an IEnumerable<> will work against the new array type. Inspection of the actual type returned will continue to be an array as before. The only potential for a breaking change would be code that depends on the defined type of the property (not the type of what's returned) being an IEnumerable<> but that seems like an odd requirement for code to depend on and is easily updated by changing the expected type.