### PR TITLE
Allow reuse of the SyslogTcpSender for long-running programs that don't need an open connection

### DIFF
--- a/SyslogNet.Client/Transport/SyslogTcpSender.cs
+++ b/SyslogNet.Client/Transport/SyslogTcpSender.cs
@@ -24,18 +24,19 @@ namespace SyslogNet.Client.Transport
 		public virtual MessageTransfer messageTransfer { get; set; }
 		public byte trailer { get; set; }
 
-		public SyslogTcpSender(string hostname, int port)
+		public SyslogTcpSender(string hostname, int port, bool connect = true)
 		{
 			this.hostname = hostname;
 			this.port = port;
 
-			Connect();
+			if (connect)
+				Connect();
 
 			messageTransfer = MessageTransfer.OctetCounting;
 			trailer = 10; // LF
 		}
 
-		protected void Connect()
+		public void Connect()
 		{
 			try
 			{
@@ -44,15 +45,30 @@ namespace SyslogNet.Client.Transport
 			}
 			catch
 			{
-				Dispose();
+				Disconnect();
 				throw;
 			}
 		}
 
 		public virtual void Reconnect()
 		{
-			Dispose();
+			Disconnect();
 			Connect();
+		}
+
+		public void Disconnect()
+		{
+			if (transportStream != null)
+			{
+				transportStream.Close();
+				transportStream = null;
+			}
+
+			if (tcpClient != null)
+			{
+				tcpClient.Close();
+				tcpClient = null;
+			}
 		}
 
 		public void Send(SyslogMessage message, ISyslogMessageSerializer serializer)
@@ -105,17 +121,7 @@ namespace SyslogNet.Client.Transport
 
 		public void Dispose()
 		{
-			if (transportStream != null)
-			{
-				transportStream.Close();
-				transportStream = null;
-			}
-
-			if (tcpClient != null)
-			{
-				tcpClient.Close();
-				tcpClient = null;
-			}
+			Disconnect();
 		}
 	}
 }

--- a/SyslogNet.Client/Transport/SyslogTcpSender.cs
+++ b/SyslogNet.Client/Transport/SyslogTcpSender.cs
@@ -24,13 +24,15 @@ namespace SyslogNet.Client.Transport
 		public virtual MessageTransfer messageTransfer { get; set; }
 		public byte trailer { get; set; }
 
-		public SyslogTcpSender(string hostname, int port, bool connect = true)
+		public SyslogTcpSender(string hostname, int port, bool shouldAutoConnect = true)
 		{
 			this.hostname = hostname;
 			this.port = port;
 
-			if (connect)
+			if (shouldAutoConnect)
+			{
 				Connect();
+			}
 
 			messageTransfer = MessageTransfer.OctetCounting;
 			trailer = 10; // LF


### PR DESCRIPTION
- In the current implementation creation of the `SyslogTcpSender` object automatically connected to the server, now it's optional.
- The current implementation was calling multiple times to `Dispose`, which is used when we no longer need the object (MSDN docs are ambiguous about this, sometimes stating that the method is called when the object is no longer needed and that multiple invocations should be ignored, and in others stating the method can be used for preparing the object for reuse, so the proposed implementation plays safe in both cases).
- With these changes, one can create the `SyslogTcpSender` object and then before sending a batch of messages call `Reconnect`, and after sending them, call `Disconnect`. So the server can serve more clients than the number of connections available.