### PR TITLE
Add asynchronous methods

### DIFF
--- a/SyslogNet.Client.Tests/SyslogNet.Client.Tests.csproj
+++ b/SyslogNet.Client.Tests/SyslogNet.Client.Tests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SyslogNet.Client.Tests</RootNamespace>
     <AssemblyName>SyslogNet.Client.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/SyslogNet.Client/SyslogNet.Client.csproj
+++ b/SyslogNet.Client/SyslogNet.Client.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SyslogNet.Client</RootNamespace>
     <AssemblyName>SyslogNet.Client</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/SyslogNet.Client/Transport/ISyslogMessageSender.cs
+++ b/SyslogNet.Client/Transport/ISyslogMessageSender.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using SyslogNet.Client.Serialization;
 
 namespace SyslogNet.Client.Transport
@@ -9,5 +10,8 @@ namespace SyslogNet.Client.Transport
 		void Reconnect();
 		void Send(SyslogMessage message, ISyslogMessageSerializer serializer);
 		void Send(IEnumerable<SyslogMessage> messages, ISyslogMessageSerializer serializer);
+		Task SendAsync(SyslogMessage message, ISyslogMessageSerializer serializer);
+		Task SendAsync(IEnumerable<SyslogMessage> messages, ISyslogMessageSerializer serializer);
+
 	}
 }

--- a/SyslogNet.Client/Transport/SyslogLocalSender.cs
+++ b/SyslogNet.Client/Transport/SyslogLocalSender.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using SyslogNet.Client.Serialization;
 
 namespace SyslogNet.Client.Transport
@@ -115,6 +116,16 @@ namespace SyslogNet.Client.Transport
 		public void Send(IEnumerable<SyslogMessage> messages)
 		{
 			Send(messages, defaultSerializer);
+		}
+		
+		public Task SendAsync(SyslogMessage message, ISyslogMessageSerializer serializer)
+		{
+			throw new NotImplementedException();
+		}
+		
+		public Task SendAsync(IEnumerable<SyslogMessage> messages, ISyslogMessageSerializer serializer)
+		{
+			throw new NotImplementedException();
 		}
 
 		public void Dispose()

--- a/SyslogNet.Client/Transport/SyslogTcpSender.cs
+++ b/SyslogNet.Client/Transport/SyslogTcpSender.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using SyslogNet.Client.Serialization;
 
 namespace SyslogNet.Client.Transport
@@ -37,9 +38,34 @@ namespace SyslogNet.Client.Transport
 
 		protected void Connect()
 		{
+			if (tcpClient != null)
+			{
+				throw new InvalidOperationException("Already connected");
+			}
+
 			try
 			{
 				tcpClient = new TcpClient(hostname, port);
+				transportStream = tcpClient.GetStream();
+			}
+			catch
+			{
+				Dispose();
+				throw;
+			}
+		}
+		
+		public async Task ConnectAsync()
+		{
+			if (tcpClient != null)
+			{
+				throw new InvalidOperationException("Already connected");
+			}
+
+			try
+			{
+				tcpClient = new TcpClient();
+				await tcpClient.ConnectAsync(hostname, port);
 				transportStream = tcpClient.GetStream();
 			}
 			catch
@@ -53,6 +79,12 @@ namespace SyslogNet.Client.Transport
 		{
 			Dispose();
 			Connect();
+		}
+		
+		public Task ReconnectAsync()
+		{
+			Dispose();
+			return ConnectAsync();
 		}
 
 		public void Send(SyslogMessage message, ISyslogMessageSerializer serializer)
@@ -69,22 +101,7 @@ namespace SyslogNet.Client.Transport
 
 			using (MemoryStream memoryStream = new MemoryStream())
 			{
-				var datagramBytes = serializer.Serialize(message);
-
-				if (messageTransfer.Equals(MessageTransfer.OctetCounting))
-				{
-					byte[] messageLength = Encoding.ASCII.GetBytes(datagramBytes.Length.ToString());
-					memoryStream.Write(messageLength, 0, messageLength.Length);
-					memoryStream.WriteByte(32); // Space
-				}
-
-				memoryStream.Write(datagramBytes, 0, datagramBytes.Length);
-
-				if (messageTransfer.Equals(MessageTransfer.NonTransparentFraming))
-				{
-					memoryStream.WriteByte(trailer); // LF
-				}
-
+				SerializeMessageToStream(message, serializer, memoryStream);
 				transportStream.Write(memoryStream.GetBuffer(), 0, (int)memoryStream.Length);
 			}
 
@@ -103,6 +120,48 @@ namespace SyslogNet.Client.Transport
 				transportStream.Flush();
 		}
 
+		public Task SendAsync(SyslogMessage message, ISyslogMessageSerializer serializer)
+		{
+			return SendAsync(message, serializer, default(CancellationToken));
+		}
+
+		public Task SendAsync(IEnumerable<SyslogMessage> messages, ISyslogMessageSerializer serializer)
+		{
+			return SendAsync(messages, serializer, default(CancellationToken));
+		}
+
+		public async Task SendAsync(SyslogMessage message, ISyslogMessageSerializer serializer, CancellationToken token)
+		{
+			if (transportStream == null)
+			{
+				throw new IOException("No transport stream exists");
+			}
+
+			using (var memoryStream = new MemoryStream())
+			{
+				SerializeMessageToStream(message, serializer, memoryStream);
+				await transportStream.WriteAsync(memoryStream.GetBuffer(), 0, (int)memoryStream.Length, token);
+			}
+
+			if (!(transportStream is NetworkStream))
+			{
+				await transportStream.FlushAsync(token);
+			}
+		}
+
+		public async Task SendAsync(IEnumerable<SyslogMessage> messages, ISyslogMessageSerializer serializer, CancellationToken token)
+		{
+			foreach (var message in messages)
+			{
+				await SendAsync(message, serializer, token);
+			}
+
+			if (!(transportStream is NetworkStream))
+			{
+				await transportStream.FlushAsync(token);
+			}
+		}
+
 		public void Dispose()
 		{
 			if (transportStream != null)
@@ -115,6 +174,25 @@ namespace SyslogNet.Client.Transport
 			{
 				tcpClient.Close();
 				tcpClient = null;
+			}
+		}
+
+		private void SerializeMessageToStream(SyslogMessage message, ISyslogMessageSerializer serializer, Stream memoryStream)
+		{
+			var datagramBytes = serializer.Serialize(message);
+
+			if (messageTransfer.Equals(MessageTransfer.OctetCounting))
+			{
+				var messageLength = Encoding.ASCII.GetBytes(datagramBytes.Length.ToString());
+				memoryStream.Write(messageLength, 0, messageLength.Length);
+				memoryStream.WriteByte(32); // Space
+			}
+
+			memoryStream.Write(datagramBytes, 0, datagramBytes.Length);
+
+			if (messageTransfer.Equals(MessageTransfer.NonTransparentFraming))
+			{
+				memoryStream.WriteByte(trailer); // LF
 			}
 		}
 	}

--- a/SyslogNet.Client/Transport/SyslogUdpSender.cs
+++ b/SyslogNet.Client/Transport/SyslogUdpSender.cs
@@ -1,7 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Sockets;
-using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using SyslogNet.Client.Serialization;
 
 namespace SyslogNet.Client.Transport
@@ -26,6 +27,20 @@ namespace SyslogNet.Client.Transport
 			foreach(SyslogMessage message in messages)
 			{
 				Send(message, serializer);
+			}
+		}
+
+		public Task SendAsync(SyslogMessage message, ISyslogMessageSerializer serializer)
+		{
+			var datagramBytes = serializer.Serialize(message);
+			return udpClient.SendAsync(datagramBytes, datagramBytes.Length);
+		}
+
+		public async Task SendAsync(IEnumerable<SyslogMessage> messages, ISyslogMessageSerializer serializer)
+		{
+			foreach(var message in messages)
+			{
+				await SendAsync(message, serializer);
 			}
 		}
 


### PR DESCRIPTION
I reduced the amount of duplication between the Sync/Async versions of each function because I realized that it doesn't make sense using the Async versions of MemoryStream, because that is writing directly to an in-memory buffer. So I checked mono's implementation of MemoryStream and it seems right, it's not async at all: https://github.com/mono/mono/blob/master/mcs/class/referencesource/mscorlib/system/io/memorystream.cs