### PR TITLE
Fix Rfc3164 wrong timestamp format in Chinese enviroment

### DIFF
--- a/SyslogNet.Client/Serialization/SyslogRfc3164MessageSerializer.cs
+++ b/SyslogNet.Client/Serialization/SyslogRfc3164MessageSerializer.cs
@@ -15,7 +15,7 @@ namespace SyslogNet.Client.Serialization
 			{
 				var dt = message.DateTimeOffset.Value;
 				var day = dt.Day < 10 ? " " + dt.Day : dt.Day.ToString(); // Yes, this is stupid but it's in the spec
-				timestamp = String.Concat(dt.ToString("MMM "), day, dt.ToString(" HH:mm:ss"));
+				timestamp = String.Concat(dt.ToString("MMM ", System.Globalization.CultureInfo.InvariantCulture), day, dt.ToString(" HH:mm:ss"));
 			}
 
 			var headerBuilder = new StringBuilder();


### PR DESCRIPTION
The timestamp in Chinese environment  generate a Chinese month

五月 5 13:22:34 message .......

This is not compliance with Rfc3164 header part.   